### PR TITLE
Fix hole lookup in add round view

### DIFF
--- a/cbg/main/views.py
+++ b/cbg/main/views.py
@@ -443,7 +443,10 @@ def add_scores(request):
                 except ValueError:
                     return HttpResponseBadRequest(f"Score for {golfer.name} on hole {hole_number} must be a number.")
 
-                hole = Hole.objects.get(number=hole_number, season=week.season)
+                hole = Hole.objects.get(
+                    number=hole_number,
+                    config=week.season.course_config,
+                )
 
                 Score.objects.update_or_create(
                     golfer=golfer,


### PR DESCRIPTION
## Summary
- fetch hole by course configuration instead of non-existent season field when saving scores

## Testing
- `SECRET_KEY=test DB_PASSWORD=test python cbg/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68adb65a55788329a7c8e50d1ed2f31c