### PR TITLE
Initialize `handicap_trend_positive` to avoid crash for golfers with no scores

### DIFF
--- a/cbg/main/views.py
+++ b/cbg/main/views.py
@@ -951,6 +951,7 @@ def golfer_stats(request, golfer_id, year=None):
         best_gross_week = worst_gross_week = best_net_week = worst_net_week = best_points_week = worst_points_week = None
         wins = losses = ties = win_percentage = 0
         handicap_trend_text = "N/A"
+        handicap_trend_positive = False
     
     # Create Plotly charts
     charts = {}
@@ -2042,6 +2043,7 @@ def sub_stats(request, golfer_id=None, year=None):
         best_gross_week = worst_gross_week = best_net_week = worst_net_week = best_points_week = worst_points_week = None
         wins = losses = ties = win_percentage = 0
         handicap_trend_text = "N/A"
+        handicap_trend_positive = False
     
     # Create Plotly charts
     charts = {}


### PR DESCRIPTION
### Motivation
- Prevent template rendering error "cannot access local variable 'handicap_trend_positive'" when a golfer has no scores/handicaps by ensuring the flag is always initialized in the view.

### Description
- Initialize `handicap_trend_positive = False` in the `weekly_stats == []` branch of `golfer_stats` in `cbg/main/views.py` so the template can safely check the flag even when no handicap data exists.
- Apply the same initialization in the analogous no-weekly-stats branch of `sub_stats` in `cbg/main/views.py` to avoid the same error there.
- No behavior changes to trend calculations when data exists; only defensive initialization was added and a trailing newline was normalized.

### Testing
- Ran `python cbg/manage.py check` in this environment and it failed due to a missing dependency (`ModuleNotFoundError: No module named 'decouple'`), so full Django system checks could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca7d1fae948329b0ec02ae691ee201)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive initialization to avoid an unbound local variable during template rendering; no changes to calculations when data exists.
> 
> **Overview**
> Prevents template rendering crashes in golfer/sub stats pages when a golfer has no recorded weekly stats by **always initializing** `handicap_trend_positive` to `False` in the empty-data branches of `golfer_stats` and `sub_stats`.
> 
> Also normalizes a trailing newline at the end of `views.py` with no functional behavior change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6442f2c6b8c571f0eca9150c1b80dd2609e753d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->