### PR TITLE
Hide placeholder handicaps on home schedule

### DIFF
--- a/cbg/main/templates/main.html
+++ b/cbg/main/templates/main.html
@@ -560,8 +560,8 @@
                         <td class="text-center fw-bold text-info">{{ forloop.counter }}</td>
                         <td class="text-center">
                           <div class="d-flex flex-column">
-                            <span class="fw-semibold">{{ matchup.high_match.0.0 }} <span class="text-muted">({{ matchup.high_match.0.1 }})</span></span>
-                            <span class="fw-semibold">{{ matchup.low_match.0.0 }} <span class="text-muted">({{ matchup.low_match.0.1 }})</span></span>
+                            <span class="fw-semibold">{{ matchup.high_match.0.0 }}{% if matchup.high_match.0.1 != 999 %} <span class="text-muted">({{ matchup.high_match.0.1 }})</span>{% endif %}</span>
+                            <span class="fw-semibold">{{ matchup.low_match.0.0 }}{% if matchup.low_match.0.1 != 999 %} <span class="text-muted">({{ matchup.low_match.0.1 }})</span>{% endif %}</span>
                           </div>
                         </td>
                         <td class="text-center">
@@ -569,8 +569,8 @@
                         </td>
                         <td class="text-center">
                           <div class="d-flex flex-column">
-                            <span class="fw-semibold">{{ matchup.high_match.1.0 }} <span class="text-muted">({{ matchup.high_match.1.1 }})</span></span>
-                            <span class="fw-semibold">{{ matchup.low_match.1.0 }} <span class="text-muted">({{ matchup.low_match.1.1 }})</span></span>
+                            <span class="fw-semibold">{{ matchup.high_match.1.0 }}{% if matchup.high_match.1.1 != 999 %} <span class="text-muted">({{ matchup.high_match.1.1 }})</span>{% endif %}</span>
+                            <span class="fw-semibold">{{ matchup.low_match.1.0 }}{% if matchup.low_match.1.1 != 999 %} <span class="text-muted">({{ matchup.low_match.1.1 }})</span>{% endif %}</span>
                           </div>
                         </td>
                       </tr>
@@ -580,8 +580,8 @@
                         <td class="text-center fw-bold text-info">{{ forloop.counter }}</td>
                         <td class="text-center">
                           <div class="d-flex flex-column">
-                            <span class="fw-semibold">{{ matchup.high_match.0.0 }} <span class="text-muted">({{ matchup.high_match.0.1 }})</span></span>
-                            <span class="fw-semibold">{{ matchup.low_match.0.0 }} <span class="text-muted">({{ matchup.low_match.0.1 }})</span></span>
+                            <span class="fw-semibold">{{ matchup.high_match.0.0 }}{% if matchup.high_match.0.1 != 999 %} <span class="text-muted">({{ matchup.high_match.0.1 }})</span>{% endif %}</span>
+                            <span class="fw-semibold">{{ matchup.low_match.0.0 }}{% if matchup.low_match.0.1 != 999 %} <span class="text-muted">({{ matchup.low_match.0.1 }})</span>{% endif %}</span>
                           </div>
                         </td>
                         <td class="text-center">
@@ -589,8 +589,8 @@
                         </td>
                         <td class="text-center">
                           <div class="d-flex flex-column">
-                            <span class="fw-semibold">{{ matchup.high_match.1.0 }} <span class="text-muted">({{ matchup.high_match.1.1 }})</span></span>
-                            <span class="fw-semibold">{{ matchup.low_match.1.0 }} <span class="text-muted">({{ matchup.low_match.1.1 }})</span></span>
+                            <span class="fw-semibold">{{ matchup.high_match.1.0 }}{% if matchup.high_match.1.1 != 999 %} <span class="text-muted">({{ matchup.high_match.1.1 }})</span>{% endif %}</span>
+                            <span class="fw-semibold">{{ matchup.low_match.1.0 }}{% if matchup.low_match.1.1 != 999 %} <span class="text-muted">({{ matchup.low_match.1.1 }})</span>{% endif %}</span>
                           </div>
                         </td>
                       </tr>


### PR DESCRIPTION
### Motivation
- The home page schedule shows `(999)` as a placeholder handicap when a golfer has no season handicap yet, which should be suppressed for clarity.

### Description
- Updated the schedule rendering in `cbg/main/templates/main.html` to only render the handicap text when the handicap value is not `999`, applying the change to both golfer-based and legacy team rows.

### Testing
- Ran a Django system check with `python manage.py check`, but it failed due to a missing dependency (`ModuleNotFoundError: No module named 'decouple'`), so template behavior was not exercised by automated checks in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4d14499483299889a737ca28866d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk template-only change that conditionally suppresses displaying the `999` placeholder handicap; no backend or data handling logic is modified.
> 
> **Overview**
> Suppresses the placeholder handicap display in the home page **Next Week Schedule**.
> 
> Updates `main.html` to only render the handicap text when the value is not `999`, applying the condition consistently for both the golfer-based and legacy team matchup rows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f784dd14e6903f692755d07c63bf2d63ea474a94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->