### PR TITLE
Add season schedule page scoped by league and year

### DIFF
--- a/cbg/main/templates/base.html
+++ b/cbg/main/templates/base.html
@@ -95,6 +95,15 @@
             {% endif %}
           </li>
           {% endif %}
+          <li class="nav-item">
+            {% if league_slug and league_nav_year %}
+            <a class="nav-link" href="{% url 'season_schedule_with_league_year' league_slug=league_slug year=league_nav_year %}">Schedule</a>
+            {% elif league_nav_year %}
+            <a class="nav-link" href="{% url 'season_schedule_with_year' league_nav_year %}">Schedule</a>
+            {% else %}
+            <a class="nav-link" href="{% url 'season_schedule' %}">Schedule</a>
+            {% endif %}
+          </li>
           {% if multiple_seasons %}
           <li class="nav-item">
             {% if league_slug %}

--- a/cbg/main/templates/season_schedule.html
+++ b/cbg/main/templates/season_schedule.html
@@ -1,0 +1,41 @@
+{% extends 'base.html' %}
+{% load scorecard_filters %}
+{% block content %}
+<div class="container mt-4">
+  <div class="card shadow-sm">
+    <div class="card-header bg-primary text-white">
+      <h3 class="mb-0">{{ season.league.name }} {{ season.year }} Schedule</h3>
+    </div>
+    <div class="card-body">
+      {% for week in weeks %}
+      <div class="mb-4">
+        <h5 class="mb-2">
+          Week {{ week.number }} — {{ week.date|date:"M d, Y" }}
+          {% if week.rained_out %}<span class="badge bg-warning text-dark">Rained Out</span>{% endif %}
+        </h5>
+        {% with matchups=matchups_by_week|get_item:week.id %}
+          {% if matchups %}
+            <ul class="list-group">
+              {% for matchup in matchups %}
+                <li class="list-group-item">
+                  {% for team in matchup.teams.all %}
+                    {% if not forloop.first %}<strong class="mx-2">vs</strong>{% endif %}
+                    {% for golfer in team.golfers.all %}
+                      {{ golfer.name }}{% if not forloop.last %} / {% endif %}
+                    {% endfor %}
+                  {% endfor %}
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="text-muted mb-0">No matchups entered.</p>
+          {% endif %}
+        {% endwith %}
+      </div>
+      {% empty %}
+      <p class="text-muted">No weeks are configured for this season.</p>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/cbg/main/urls.py
+++ b/cbg/main/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path('<slug:league_slug>/<year:year>/sub_stats/', views.sub_stats, name='sub_stats_with_league_year'),
     path('<slug:league_slug>/<year:year>/sub_stats/<int:golfer_id>/', views.sub_stats, name='sub_stats_detail_with_league_year'),
     path('<slug:league_slug>/<year:year>/league_stats/', views.league_stats, name='league_stats_with_league_year'),
+    path('<slug:league_slug>/<year:year>/schedule/', views.season_schedule, name='season_schedule_with_league_year'),
     # League-scoped management (year = season calendar year)
     path('<slug:league_slug>/<year:year>/add_round/', views.add_scores, name='add_round_with_league_year'),
     path('<slug:league_slug>/<year:year>/add_golfer/', views.add_golfer, name='add_golfer_with_league_year'),
@@ -48,6 +49,7 @@ urlpatterns = [
     path('sub_stats/', views.sub_stats, name="sub_stats"),
     path('sub_stats/<int:golfer_id>/', views.sub_stats, name="sub_stats_detail"),
     path('league_stats/', views.league_stats, name="league_stats"),
+    path('schedule/', views.season_schedule, name='season_schedule'),
     path('set_rainout', views.set_rainout, name='set_rainout'),
     path('create_season', views.create_season, name='create_season'),
     path('edit_season/<int:season_id>/', views.edit_season, name='edit_season'),
@@ -71,6 +73,7 @@ urlpatterns = [
     path('<year:year>/sub_stats/', views.sub_stats, name="sub_stats_with_year"),
     path('<year:year>/sub_stats/<int:golfer_id>/', views.sub_stats, name="sub_stats_detail_with_year"),
     path('<year:year>/league_stats/', views.league_stats, name="league_stats_with_year"),
+    path('<year:year>/schedule/', views.season_schedule, name='season_schedule_with_year'),
     path('historics/', views.historics, name='historics'),
     
     # Week patterns (must come after year patterns to avoid conflicts)

--- a/cbg/main/views.py
+++ b/cbg/main/views.py
@@ -811,6 +811,33 @@ def enter_schedule(request, league_slug=None, year=None):
     return render(request, 'enter_schedule.html', {'form': form, 'message': message, 'message_type': message_type})
 
 
+
+def season_schedule(request, year=None, league_slug=None):
+    league = resolve_league(league_slug)
+    season = get_current_season(year, league) if year else get_current_season(league=league)
+    if not season:
+        return redirect_home(league, year)
+
+    weeks = Week.objects.filter(season=season).order_by('number')
+    matchups_by_week = {
+        week.id: list(
+            Matchup.objects.filter(week=week)
+            .prefetch_related('teams__golfers')
+            .order_by('id')
+        )
+        for week in weeks
+    }
+
+    return render(
+        request,
+        'season_schedule.html',
+        {
+            'season': season,
+            'weeks': weeks,
+            'matchups_by_week': matchups_by_week,
+        },
+    )
+
 def golfer_stats(request, golfer_id, year=None, league_slug=None):
     import json
     from django.db.models import Avg, Count, Q, Min, Max


### PR DESCRIPTION
### Motivation
- Provide a read-only, season-level schedule view so users can see all weeks and matchups for a league + season year in one place. 
- Reuse existing league/year resolution logic so the schedule page works for `/<league_slug>/<year>/`, `/<year>/`, and the default site context.

### Description
- Added a new view `season_schedule` in `cbg/main/views.py` that resolves league and season via `resolve_league`/`get_current_season`, loads `Week` rows, and collects `Matchup` objects into `matchups_by_week` using `prefetch_related('teams__golfers')` for efficient rendering. 
- Registered new URL routes in `cbg/main/urls.py` for `/<slug:league_slug>/<year>/schedule/`, `/<year>/schedule/`, and `/schedule/` mapped to the `season_schedule` view. 
- Added `cbg/main/templates/season_schedule.html` to render weeks, dates, rainout badges, and team golfer names with graceful empty states. 
- Inserted a top-nav "Schedule" link into `cbg/main/templates/base.html` that correctly links for league/year, year-only, and default contexts.

### Testing
- Ran `cd cbg && python manage.py check` to validate the Django configuration, which could not complete due to a missing runtime dependency and failed with `ModuleNotFoundError: No module named 'decouple'` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d230ac50832981eb38ee3d4cde16)