### PR TITLE
Add season schedule view, template, URLs and navbar link

### DIFF
--- a/cbg/main/templates/base.html
+++ b/cbg/main/templates/base.html
@@ -95,6 +95,15 @@
             {% endif %}
           </li>
           {% endif %}
+          <li class="nav-item">
+            {% if league_slug and league_nav_year %}
+            <a class="nav-link" href="{% url 'season_schedule_with_league_year' league_slug=league_slug year=league_nav_year %}">Schedule</a>
+            {% elif league_nav_year %}
+            <a class="nav-link" href="{% url 'season_schedule_with_year' league_nav_year %}">Schedule</a>
+            {% else %}
+            <a class="nav-link" href="{% url 'season_schedule' %}">Schedule</a>
+            {% endif %}
+          </li>
           {% if multiple_seasons %}
           <li class="nav-item">
             {% if league_slug %}

--- a/cbg/main/templates/season_schedule.html
+++ b/cbg/main/templates/season_schedule.html
@@ -1,0 +1,70 @@
+{% extends 'base.html' %}
+{% load scorecard_filters %}
+{% block content %}
+<div class="container mt-4">
+  <div class="card shadow-sm mb-3">
+    <div class="card-body">
+      <form method="get" class="row g-2 align-items-end">
+        <div class="col-md-5">
+          <label class="form-label">League</label>
+          <select name="league" class="form-select" onchange="this.form.submit()">
+            <option value="">Select a league</option>
+            {% for league_option in league_options %}
+              <option value="{{ league_option.id }}" {% if league and league_option.id == league.id %}selected{% endif %}>{{ league_option.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="col-md-5">
+          <label class="form-label">Season</label>
+          <select name="year" class="form-select" {% if not league %}disabled{% endif %} onchange="this.form.submit()">
+            <option value="">Latest season</option>
+            {% for season_option in season_options %}
+              <option value="{{ season_option.year }}" {% if season and season_option.year == season.year %}selected{% endif %}>{{ season_option.year }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  {% if season %}
+  <div class="card shadow-sm">
+    <div class="card-header bg-primary text-white">
+      <h3 class="mb-0">{{ season.league.name }} {{ season.year }} Schedule</h3>
+    </div>
+    <div class="card-body">
+      {% for week in weeks %}
+      <div class="mb-4">
+        <h5 class="mb-2">
+          Week {{ week.number }} — {{ week.date|date:"M d, Y" }}
+          {% if week.rained_out %}<span class="badge bg-warning text-dark">Rained Out</span>{% endif %}
+        </h5>
+        {% with matchups=matchups_by_week|get_item:week.id %}
+          {% if matchups %}
+            <ul class="list-group">
+              {% for matchup in matchups %}
+                <li class="list-group-item">
+                  {% for team in matchup.teams.all %}
+                    {% if not forloop.first %}<strong class="mx-2">vs</strong>{% endif %}
+                    {% for golfer in team.golfers.all %}
+                      {{ golfer.name }}{% if not forloop.last %} / {% endif %}
+                    {% endfor %}
+                  {% endfor %}
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="text-muted mb-0">No matchups entered.</p>
+          {% endif %}
+        {% endwith %}
+      </div>
+      {% empty %}
+      <p class="text-muted">No weeks are configured for this season.</p>
+      {% endfor %}
+    </div>
+  </div>
+  {% else %}
+  <div class="alert alert-info">Select a league and season to view the schedule.</div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/cbg/main/urls.py
+++ b/cbg/main/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path('<slug:league_slug>/<year:year>/sub_stats/', views.sub_stats, name='sub_stats_with_league_year'),
     path('<slug:league_slug>/<year:year>/sub_stats/<int:golfer_id>/', views.sub_stats, name='sub_stats_detail_with_league_year'),
     path('<slug:league_slug>/<year:year>/league_stats/', views.league_stats, name='league_stats_with_league_year'),
+    path('<slug:league_slug>/<year:year>/schedule/', views.season_schedule, name='season_schedule_with_league_year'),
     # League-scoped management (year = season calendar year)
     path('<slug:league_slug>/<year:year>/add_round/', views.add_scores, name='add_round_with_league_year'),
     path('<slug:league_slug>/<year:year>/add_golfer/', views.add_golfer, name='add_golfer_with_league_year'),
@@ -48,6 +49,7 @@ urlpatterns = [
     path('sub_stats/', views.sub_stats, name="sub_stats"),
     path('sub_stats/<int:golfer_id>/', views.sub_stats, name="sub_stats_detail"),
     path('league_stats/', views.league_stats, name="league_stats"),
+    path('schedule/', views.season_schedule, name='season_schedule'),
     path('set_rainout', views.set_rainout, name='set_rainout'),
     path('create_season', views.create_season, name='create_season'),
     path('edit_season/<int:season_id>/', views.edit_season, name='edit_season'),
@@ -71,6 +73,7 @@ urlpatterns = [
     path('<year:year>/sub_stats/', views.sub_stats, name="sub_stats_with_year"),
     path('<year:year>/sub_stats/<int:golfer_id>/', views.sub_stats, name="sub_stats_detail_with_year"),
     path('<year:year>/league_stats/', views.league_stats, name="league_stats_with_year"),
+    path('<year:year>/schedule/', views.season_schedule, name='season_schedule_with_year'),
     path('historics/', views.historics, name='historics'),
     
     # Week patterns (must come after year patterns to avoid conflicts)

--- a/cbg/main/views.py
+++ b/cbg/main/views.py
@@ -811,6 +811,54 @@ def enter_schedule(request, league_slug=None, year=None):
     return render(request, 'enter_schedule.html', {'form': form, 'message': message, 'message_type': message_type})
 
 
+
+def season_schedule(request, year=None, league_slug=None):
+    league = resolve_league(league_slug)
+
+    requested_league_id = request.GET.get('league')
+    if requested_league_id and not league_slug:
+        league = League.objects.filter(pk=requested_league_id).first() or league
+
+    requested_year = request.GET.get('year')
+    if requested_year and year is None:
+        try:
+            year = int(requested_year)
+        except (TypeError, ValueError):
+            year = None
+
+    season = get_current_season(year, league) if year else get_current_season(league=league)
+
+    league_options = League.objects.all().order_by('name')
+    season_options = Season.objects.none()
+    if league:
+        season_options = Season.objects.filter(league=league).order_by('-year')
+
+    weeks = Week.objects.none()
+    matchups_by_week = {}
+    if season:
+        weeks = Week.objects.filter(season=season).order_by('number')
+        season_matchups = (
+            Matchup.objects.filter(week__season=season)
+            .select_related('week')
+            .prefetch_related('teams__golfers')
+            .order_by('week__number', 'id')
+        )
+        for matchup in season_matchups:
+            matchups_by_week.setdefault(matchup.week_id, []).append(matchup)
+
+    return render(
+        request,
+        'season_schedule.html',
+        {
+            'league': league,
+            'season': season,
+            'weeks': weeks,
+            'matchups_by_week': matchups_by_week,
+            'league_options': league_options,
+            'season_options': season_options,
+        },
+    )
+
 def golfer_stats(request, golfer_id, year=None, league_slug=None):
     import json
     from django.db.models import Avg, Count, Q, Min, Max


### PR DESCRIPTION
### Motivation

- Provide a dedicated schedule page to view season matchups by league and year for easier navigation and inspection.
- Expose both league-scoped and year-scoped routes and add a top-level nav link so users can access schedules from the main UI.

### Description

- Added a `season_schedule` view in `views.py` that resolves the league and year, loads `Week` and `Matchup` data, groups matchups by week, and populates `league_options` and `season_options` for the selector controls. 
- Created a new template `season_schedule.html` that extends `base.html` and renders league/season selectors plus a per-week list of matchups with rained-out badges and fallback messaging. 
- Registered new URL patterns in `urls.py` for `schedule/`, `<year:year>/schedule/`, and `<slug:league_slug>/<year:year>/schedule/` named `season_schedule`, `season_schedule_with_year`, and `season_schedule_with_league_year` respectively. 
- Added a `Schedule` nav link in `base.html` that routes to the appropriate schedule URL depending on the current league/year context.

### Testing

- Ran the project's automated test suite with `python manage.py test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d230ac50832981eb38ee3d4cde16)