### PR TITLE
Render matchup strings in schedule template and add golfer-level fallback in view

### DIFF
--- a/cbg/main/templates/season_schedule.html
+++ b/cbg/main/templates/season_schedule.html
@@ -17,14 +17,7 @@
           {% if matchups %}
             <ul class="list-group">
               {% for matchup in matchups %}
-                <li class="list-group-item">
-                  {% for team in matchup.teams.all %}
-                    {% if not forloop.first %}<strong class="mx-2">vs</strong>{% endif %}
-                    {% for golfer in team.golfers.all %}
-                      {{ golfer.name }}{% if not forloop.last %} / {% endif %}
-                    {% endfor %}
-                  {% endfor %}
-                </li>
+                <li class="list-group-item">{{ matchup }}</li>
               {% endfor %}
             </ul>
           {% else %}

--- a/cbg/main/views.py
+++ b/cbg/main/views.py
@@ -819,14 +819,37 @@ def season_schedule(request, year=None, league_slug=None):
         return redirect_home(league, year)
 
     weeks = Week.objects.filter(season=season).order_by('number')
-    matchups_by_week = {
-        week.id: list(
+    matchups_by_week = {}
+    for week in weeks:
+        display_rows = []
+        team_matchups = list(
             Matchup.objects.filter(week=week)
             .prefetch_related('teams__golfers')
             .order_by('id')
         )
-        for week in weeks
-    }
+
+        if team_matchups:
+            for matchup in team_matchups:
+                teams = list(matchup.teams.all())
+                if len(teams) != 2:
+                    continue
+                team1_names = ' / '.join(g.name for g in teams[0].golfers.all())
+                team2_names = ' / '.join(g.name for g in teams[1].golfers.all())
+                if team1_names and team2_names:
+                    display_rows.append(f'{team1_names} vs {team2_names}')
+        else:
+            # Fallback for datasets with golfer-level matchups but missing team-level Matchup rows.
+            derived_schedule = get_golfer_schedule(week) or []
+            for row in derived_schedule:
+                high_match = row.get('high_match') if isinstance(row, dict) else None
+                low_match = row.get('low_match') if isinstance(row, dict) else None
+
+                if high_match and len(high_match) == 2:
+                    display_rows.append(f"{high_match[0][0]} vs {high_match[1][0]}")
+                if low_match and len(low_match) == 2 and low_match[0][0] and low_match[1][0]:
+                    display_rows.append(f"{low_match[0][0]} vs {low_match[1][0]}")
+
+        matchups_by_week[week.id] = display_rows
 
     return render(
         request,


### PR DESCRIPTION
### Motivation
- Simplify schedule rendering by presenting each matchup as a single display string instead of nested team/golfer loops.  
- Handle legacy or incomplete data where team-level `Matchup` rows are missing by deriving matchups from golfer-level schedules.

### Description
- Simplified `season_schedule.html` to render `{{ matchup }}` directly instead of iterating `matchup.teams` and `team.golfers`.  
- Rewrote `season_schedule` view to build `matchups_by_week` explicitly by iterating `weeks` and collecting formatted strings for each matchup.  
- Format team sides by joining golfer names with ` / ` and joining teams with ` vs `, and skip malformed matchups where a matchup does not have exactly two teams.  
- Added a fallback path that calls `get_golfer_schedule(week)` when no team-level `Matchup` rows exist and extracts `high_match` and `low_match` pairs into display rows.

### Testing
- Ran the existing Django test suite via `./manage.py test` and all tests passed.  
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072278beb08329bca91136671a8eb4)